### PR TITLE
Use a fixed step size when sampling points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
                 <configuration>

--- a/src/main/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategy.java
+++ b/src/main/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategy.java
@@ -58,7 +58,7 @@ public class SamplingMedianDistanceThresholdSelectionStrategy<P, E extends P> ex
      *
      * @return a list containing at most the number of points chosen at construction time
      */
-    private List<E> getSampledPoints(final List<E> points) {
+    List<E> getSampledPoints(final List<E> points) {
         final List<E> sampledPoints;
 
         if (points.size() > this.numberOfSamples) {

--- a/src/main/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategy.java
+++ b/src/main/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategy.java
@@ -19,6 +19,14 @@ public class SamplingMedianDistanceThresholdSelectionStrategy<P, E extends P> ex
     public static final int DEFAULT_NUMBER_OF_SAMPLES = 32;
 
     /**
+     * Constructs a threshold selector that uses up to a default ({@value DEFAULT_NUMBER_OF_SAMPLES}) number of samples
+     * from a list of points to choose a median distance.
+     */
+    public SamplingMedianDistanceThresholdSelectionStrategy() {
+        this(DEFAULT_NUMBER_OF_SAMPLES);
+    }
+
+    /**
      * Constructs a threshold selector that uses up to the given number of samples from a list of points to choose a
      * median distance.
      *
@@ -52,13 +60,13 @@ public class SamplingMedianDistanceThresholdSelectionStrategy<P, E extends P> ex
      */
     private List<E> getSampledPoints(final List<E> points) {
         final List<E> sampledPoints;
-        final int numberOfPoints = points.size();
 
-        if (numberOfPoints > this.numberOfSamples) {
+        if (points.size() > this.numberOfSamples) {
             sampledPoints = new ArrayList<>(this.numberOfSamples);
+            final int step = points.size() / this.numberOfSamples;
 
             for (int i = 0; i < this.numberOfSamples; i++) {
-                sampledPoints.add(points.get((i * numberOfPoints) / this.numberOfSamples));
+                sampledPoints.add(points.get(i * step));
             }
         } else {
             sampledPoints = points;

--- a/src/test/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategyTest.java
+++ b/src/test/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategyTest.java
@@ -1,0 +1,41 @@
+package com.eatthepath.jvptree.util;
+
+import com.eatthepath.jvptree.DistanceFunction;
+import com.eatthepath.jvptree.IntegerDistanceFunction;
+import org.junit.jupiter.api.Test;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SamplingMedianDistanceThresholdSelectionStrategyTest {
+
+    private static class FakeGiganticList extends AbstractList<Integer> {
+
+        @Override
+        public Integer get(final int index) {
+            if (index >= size() || index < 0) {
+                throw new IndexOutOfBoundsException();
+            }
+
+            return index;
+        }
+
+        @Override
+        public int size() {
+            return 305574400;
+        }
+    }
+
+    @Test
+    void selectThreshold() {
+        final SamplingMedianDistanceThresholdSelectionStrategy<Integer, Integer> strategy =
+                new SamplingMedianDistanceThresholdSelectionStrategy<>();
+
+        final List<Integer> points = new FakeGiganticList();
+
+        assertDoesNotThrow(() -> strategy.selectThreshold(points, 17, (a, b) -> Math.abs(a - b)));
+    }
+}

--- a/src/test/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategyTest.java
+++ b/src/test/java/com/eatthepath/jvptree/util/SamplingMedianDistanceThresholdSelectionStrategyTest.java
@@ -5,6 +5,7 @@ import com.eatthepath.jvptree.IntegerDistanceFunction;
 import org.junit.jupiter.api.Test;
 
 import java.util.AbstractList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -30,7 +31,16 @@ class SamplingMedianDistanceThresholdSelectionStrategyTest {
     }
 
     @Test
-    void selectThreshold() {
+    void getSampledPoints() {
+        final SamplingMedianDistanceThresholdSelectionStrategy<Integer, Integer> strategy =
+                new SamplingMedianDistanceThresholdSelectionStrategy<>(5);
+
+        assertEquals(Arrays.asList(1, 3, 5, 7, 9),
+                strategy.getSampledPoints(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+    }
+
+    @Test
+    void selectThresholdOverflow() {
         final SamplingMedianDistanceThresholdSelectionStrategy<Integer, Integer> strategy =
                 new SamplingMedianDistanceThresholdSelectionStrategy<>();
 


### PR DESCRIPTION
This fixes #9, an issue where we were using a poor numerical conditioning strategy that could lead to integer overflows when sampling lists.